### PR TITLE
Movie rename/redirect handling

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -65,8 +65,14 @@ jobs:
           TMDB_KEY: ${{ secrets.TMDB_KEY }}
         run: cd data_processing && pipenv run python get_movies.py
       
-      - name: Prune inactive data
+      - name: Prune inactive movie data from database
         env:
           CONNECTION_URL: ${{ secrets.CONNECTION_URL }}
           MONGO_DB: ${{ secrets.MONGO_DB }}
-        run: cd data_processing && pipenv run python prune_db.py
+        run: cd data_processing && pipenv run python prune_inactive_movies.py
+      
+      - name: Consolidate/migrate data for any movies that now redirect to other pages
+        env:
+          CONNECTION_URL: ${{ secrets.CONNECTION_URL }}
+          MONGO_DB: ${{ secrets.MONGO_DB }}
+        run: cd data_processing && pipenv run python consolidate_redirects.py

--- a/data_processing/consolidate_redirects.py
+++ b/data_processing/consolidate_redirects.py
@@ -1,0 +1,182 @@
+#!/usr/local/bin/python3.12
+
+import argparse
+import datetime as datetime
+
+# Use your existing DB helper
+from db_connect import connect_to_db
+from pymongo import ASCENDING
+from pymongo.errors import PyMongoError
+from tqdm import tqdm
+
+
+def archive_old_ratings(db, retired_db, old_id: str, new_id: str) -> None:
+    """Copy old-id ratings into retired_entries.ratings with audit fields."""
+    pipeline = [
+        {"$match": {"movie_id": old_id}},
+        {
+            "$addFields": {
+                "migrated_at": "$$NOW",
+                "redirect_from": old_id,
+                "redirect_to": new_id,
+            }
+        },
+        {
+            "$merge": {
+                "into": {"db": retired_db.name, "coll": "ratings"},
+                "whenMatched": "keepExisting",
+                "whenNotMatched": "insert",
+            }
+        },
+    ]
+    db.ratings.aggregate(pipeline, allowDiskUse=True)
+
+
+def archive_old_movie(db, retired_db, old_id: str, new_id: str) -> None:
+    """Copy old movie doc into retired_entries.movies with redirect markers."""
+    pipeline = [
+        {"$match": {"movie_id": old_id}},
+        {
+            "$addFields": {
+                "migrated_at": "$$NOW",
+                "redirected_at": "$$NOW",
+                "redirect_to": new_id,
+                "scrape_status": "redirected",
+            }
+        },
+        {
+            "$merge": {
+                "into": {"db": retired_db.name, "coll": "movies"},
+                "whenMatched": "replace",
+                "whenNotMatched": "insert",
+            }
+        },
+    ]
+    db.movies.aggregate(pipeline, allowDiskUse=True)
+
+
+def iter_redirect_pairs(redirects_coll, only_status="pending"):
+    q = {"new_id": {"$type": "string"}, "old_id": {"$type": "string"}}
+    if only_status is not None:
+        q["status"] = only_status
+
+    for doc in redirects_coll.find(q, {"_id": 1, "old_id": 1, "new_id": 1}):
+        old_id, new_id = doc.get("old_id"), doc.get("new_id")
+        if old_id and new_id and old_id != new_id:
+            yield (doc["_id"], old_id, new_id)  # keep ObjectId
+
+
+def ensure_indexes(db):
+    # movie_redirects typically small; index old_id helps a bit
+    db.movie_redirects.create_index([("old_id", ASCENDING)])
+
+
+def migrate_ratings_one_pair(db, retired_db, old_id: str, new_id: str):
+    """
+    Archive old-id ratings -> retired_entries.ratings, then remap in-place to new_id,
+    then delete the old-id rows from main db.
+    """
+    # Archive the originals (to keep a record of what was removed)
+    archive_old_ratings(db, retired_db, old_id, new_id)
+
+    # Merge remapped rows back to main ratings under new_id (deduped by user_id+movie_id)
+    pipeline = [
+        {"$match": {"movie_id": old_id}},
+        {"$addFields": {"movie_id": new_id}},
+        {"$unset": "_id"},  # avoid duplicate _id on insert
+        {
+            "$merge": {
+                "into": "ratings",
+                "on": ["user_id", "movie_id"],
+                "whenMatched": "keepExisting",  # don't overwrite if user already has a rating for new_id
+                "whenNotMatched": "insert",
+            }
+        },
+    ]
+    db.ratings.aggregate(pipeline, allowDiskUse=True)
+
+    # Delete old_id rows from main db
+    deleted = db.ratings.delete_many({"movie_id": old_id}).deleted_count
+    return (None, deleted)
+
+
+def mark_movie_redirected(db, old_id: str, new_id: str) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    db.movies.update_one(
+        {"movie_id": old_id},
+        {
+            "$set": {
+                "scrape_status": "redirected",
+                "redirect_to": new_id,
+                "redirected_at": now,
+            }
+        },
+    )
+
+
+def delete_old_movie(db, retired_db, old_id: str, new_id: str) -> int:
+    """
+    Archive old movie doc to retired_entries.movies, then delete from main DB.
+    Returns delete count (0/1).
+    """
+    archive_old_movie(db, retired_db, old_id, new_id)
+    return db.movies.delete_one({"movie_id": old_id}).deleted_count
+
+
+def complete_redirect_row(redirects_coll, doc_id, stats: dict) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    redirects_coll.update_one(
+        {"_id": doc_id},  # <- ObjectId now
+        {"$set": {"status": "merged", "merged_at": now, **stats}},
+    )
+
+
+def process_all_redirects(db, batch_limit: int) -> None:
+    redirects = db.movie_redirects
+    retired_db = db.client["retired_entries"]
+
+    db.movie_redirects.create_index([("old_id", ASCENDING)])
+
+    pairs = list(iter_redirect_pairs(redirects, only_status="pending"))
+    if batch_limit and batch_limit > 0:
+        pairs = pairs[:batch_limit]
+
+    print(f"Found {len(pairs)} pending redirects.")
+    for doc_id, old_id, new_id in tqdm(pairs, desc="Merging"):
+        try:
+            inserted_kept, deleted = migrate_ratings_one_pair(
+                db, retired_db, old_id, new_id
+            )
+            mark_movie_redirected(db, old_id, new_id)
+            deleted_movies = delete_old_movie(db, retired_db, old_id, new_id)
+
+            stats = {
+                "ratings_migrated": deleted,
+                "movie_migrated": deleted_movies,
+                "redirect_to": new_id,
+            }
+            complete_redirect_row(redirects, doc_id, stats)
+        except PyMongoError as e:
+            print(f"[WARN] Failed to merge {old_id} → {new_id}: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Consolidate movie ID redirects and archive inactive records."
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Process only the first N redirects (for testing).",
+    )
+    args = parser.parse_args()
+
+    db_name, client = connect_to_db()
+    db = client[db_name]
+
+    process_all_redirects(db, batch_limit=args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/data_processing/get_movies.py
+++ b/data_processing/get_movies.py
@@ -204,7 +204,6 @@ def handle_redirects(r, movie_update_object, movie_id, mongo_db):
             "$set": {
                 "old_id": movie_id,
                 "new_id": redirect_to,
-                "first_seen_at": datetime.datetime.now(datetime.timezone.utc),
                 "last_seen_at": datetime.datetime.now(datetime.timezone.utc),
                 "status": "pending",  # will flip to 'merged' after consolidation
             }
@@ -416,7 +415,7 @@ def get_ids_for_update(movies_collection, data_type):
                                 {"movie_title": {"$in": ["", None]}},
                                 {"tmdb_id": {"$in": ["", None]}},
                                 {"image_url": {"$in": ["", None]}},
-                                # {"content_type": {"$in": ["", None]}},
+                                {"content_type": {"$in": ["", None]}},
                             ]
                         },
                         {

--- a/data_processing/get_movies.py
+++ b/data_processing/get_movies.py
@@ -203,9 +203,10 @@ async def fetch_tmdb_data(url, session, movie_data, input_data={}):
 
         object_fields = ["genres", "production_countries", "spoken_languages"]
         for field_name in object_fields:
-            try:
-                movie_object[field_name] = [x["name"] for x in response[field_name]]
-            except:
+            data = response.get(field_name)
+            if isinstance(data, list):
+                movie_object[field_name] = [x.get("name") for x in data if "name" in x]
+            else:
                 movie_object[field_name] = None
 
         simple_fields = [
@@ -218,10 +219,7 @@ async def fetch_tmdb_data(url, session, movie_data, input_data={}):
             "original_language",
         ]
         for field_name in simple_fields:
-            try:
-                movie_object[field_name] = response[field_name]
-            except:
-                movie_object[field_name] = None
+            movie_object[field_name] = response.get(field_name)
 
         movie_object["last_updated"] = datetime.datetime.now(datetime.timezone.utc)
 

--- a/data_processing/get_ratings.py
+++ b/data_processing/get_ratings.py
@@ -165,7 +165,7 @@ async def generate_ratings_operations(response, send_to_db=True, return_unrated=
 
         rating_el = review.select_one("span.rating")
         if not rating_el:
-            if return_unrated == False:
+            if not return_unrated:
                 continue
             else:
                 rating_val = -1
@@ -263,7 +263,7 @@ async def get_user_ratings(
 
     parse_responses = await asyncio.gather(*tasks)
 
-    if store_in_db == False:
+    if not store_in_db:
         parse_responses = list(
             chain.from_iterable(list(chain.from_iterable(parse_responses)))
         )

--- a/data_processing/get_user_ratings.py
+++ b/data_processing/get_user_ratings.py
@@ -10,7 +10,8 @@ import requests
 from bs4 import BeautifulSoup
 from pymongo import ReplaceOne, UpdateOne
 from pymongo.errors import BulkWriteError
-from pymongo.operations import ReplaceOne
+
+# from pymongo.operations import ReplaceOne
 
 if os.getcwd().endswith("/data_processing"):
     from get_ratings import get_user_ratings

--- a/data_processing/prune_inactive_movies.py
+++ b/data_processing/prune_inactive_movies.py
@@ -1,5 +1,5 @@
 #!/usr/local/bin/python3.12
-"""prune_db.py: Find inactive/dead movie links in database and remove entries/corresponding ratings entries (migrate them to retired db)"""
+"""prune_inactive_movies.py: Find inactive/dead movie links in database and remove entries/corresponding ratings entries (migrate them to retired db)"""
 
 import datetime
 


### PR DESCRIPTION
Adds a new handler script in the data update pipeline that tracks when movie pages redirect to other pages (sometimes entries are renamed or are former collections that are setup to redirect, etc). Happens more with foreign films where the translation of the title is sometimes corrected/updated.

These redirects are now flagged in `get_movies.py` with some attached data in `movies` and in a small helper collection called `movie_redirects`. Then, the `consolidate_redirects.py` script will consolidate any redirected `movie` entries and consolidate any associated `ratings` and then migrate any that need to be deleted to the `retired_entries` db. Eventually, this should fix the occasional issue with recommendations for movies where the letterboxd entry no longer exists, such as [https://letterboxd.com/film/the-lord-of-the-rings-2003/](https://letterboxd.com/film/the-lord-of-the-rings-2003/), which now redirects to [https://letterboxd.com/film/the-lord-of-the-rings-the-fellowship-of-the-ring/](https://letterboxd.com/film/the-lord-of-the-rings-the-fellowship-of-the-ring/) and creates some minor issues with the front-facing site, as well as with the data-gathering crawls.

Made some small refactoring changes on `get_movies.py` too. Mostly scaffolded out `consolidate_redirects.py` with the help of an LLM and then cleaned it up a little and validated it. Wasn't too precious about the way it was written or efficiency/performance, given that it's an occasional script run over a few dozen/hundred entries at most.