### PR TITLE
Add language filter, runtime filter, and genre toggle

### DIFF
--- a/frontend/src/components/ListFilters.jsx
+++ b/frontend/src/components/ListFilters.jsx
@@ -12,6 +12,8 @@ import Chip from "@mui/material/Chip";
 import ListItemText from "@mui/material/ListItemText";
 import Checkbox from "@mui/material/Checkbox";
 import Slider from "@mui/material/Slider";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
 
 import "../styles/ListFilters.scss";
 // import LabeledSlider from "./ui/LabeledSlider";
@@ -44,6 +46,8 @@ const ListFilters = ({
   setFilteredPopularityRange,
   excludeWatchlist,
   setExcludeWatchlist,
+  setFilteredLanguage,
+  setMaxRuntime,
 }) => {
   const allGenres = useMemo(() => {
     return [
@@ -54,6 +58,57 @@ const ListFilters = ({
           .filter((d) => d && d !== ""),
       ),
     ].sort();
+  }, [results]);
+
+  const LANGUAGE_NAMES = {
+    en: "English",
+    fr: "French",
+    ja: "Japanese",
+    ko: "Korean",
+    es: "Spanish",
+    de: "German",
+    it: "Italian",
+    zh: "Chinese",
+    pt: "Portuguese",
+    ru: "Russian",
+    hi: "Hindi",
+    ar: "Arabic",
+    sv: "Swedish",
+    da: "Danish",
+    pl: "Polish",
+    th: "Thai",
+    tr: "Turkish",
+    nl: "Dutch",
+    cs: "Czech",
+    no: "Norwegian",
+    fi: "Finnish",
+    fa: "Persian",
+    bn: "Bengali",
+    el: "Greek",
+    he: "Hebrew",
+    hu: "Hungarian",
+    id: "Indonesian",
+    ms: "Malay",
+    ro: "Romanian",
+    uk: "Ukrainian",
+    vi: "Vietnamese",
+    tl: "Tagalog",
+    te: "Telugu",
+    ta: "Tamil",
+    ml: "Malayalam",
+    cn: "Cantonese",
+  };
+
+  const allLanguages = useMemo(() => {
+    return [
+      ...new Set(
+        results
+          .map((d) => d.movie_data.original_language)
+          .filter((l) => l && l !== ""),
+      ),
+    ].sort((a, b) =>
+      (LANGUAGE_NAMES[a] ?? a).localeCompare(LANGUAGE_NAMES[b] ?? b),
+    );
   }, [results]);
 
   const allYears = useMemo(() => {
@@ -87,6 +142,7 @@ const ListFilters = ({
     excluded: ["Music"],
   });
   const [yearRange, setYearRange] = useState(allYears);
+  const [language, setLanguage] = useState("");
   // const [popularity, setPopularity] = useState(popularityRange);
 
   useEffect(() => {
@@ -125,6 +181,16 @@ const ListFilters = ({
     },
     [setYearRange, setFilteredYearRange],
   );
+
+  const handleGenreToggleAll = useCallback(() => {
+    const allSelected = genres.included.length === allGenres.length;
+    const newIncluded = allSelected ? [] : allGenres;
+    setGenres((curr) => ({ ...curr, included: newIncluded }));
+    setFilteredGenres({
+      included: allSelected ? [] : null,
+      excluded: genres.excluded,
+    });
+  }, [genres, allGenres, setFilteredGenres]);
 
   // const handlePopularityChange = useCallback(
   //   (_, newValue) => {
@@ -222,6 +288,15 @@ const ListFilters = ({
             </MenuItem>
           ))}
         </Select>
+        <Button
+          size="small"
+          onClick={handleGenreToggleAll}
+          sx={{ mt: 0.5, alignSelf: "flex-start" }}
+        >
+          {genres.included.length === allGenres.length
+            ? "Clear All"
+            : "Select All"}
+        </Button>
       </FormControl>
 
       <FormControl sx={{ m: 1, width: 400, maxWidth: "90vw" }}>
@@ -268,6 +343,43 @@ const ListFilters = ({
             </MenuItem>
           ))}
         </Select>
+      </FormControl>
+
+      <FormControl sx={{ m: 1, width: 400, maxWidth: "90vw" }}>
+        <InputLabel id="language-filter-label">Language</InputLabel>
+        <Select
+          labelId="language-filter-label"
+          id="language-filter"
+          value={language}
+          onChange={(e) => {
+            setLanguage(e.target.value);
+            setFilteredLanguage(e.target.value === "" ? null : e.target.value);
+          }}
+          input={<OutlinedInput label="Language" />}
+          MenuProps={MenuProps}
+        >
+          <MenuItem value="">
+            <em>All</em>
+          </MenuItem>
+          {allLanguages.map((code) => (
+            <MenuItem key={code} value={code}>
+              {LANGUAGE_NAMES[code] ?? code}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl sx={{ m: 1, width: 400, maxWidth: "90vw" }}>
+        <TextField
+          id="runtime-filter"
+          label="Max Runtime (min)"
+          type="number"
+          InputLabelProps={{ shrink: true }}
+          onChange={(e) => {
+            const val = e.target.value;
+            setMaxRuntime(val === "" ? null : Number(val));
+          }}
+        />
       </FormControl>
 
       <FormControlLabel

--- a/frontend/src/components/Results.jsx
+++ b/frontend/src/components/Results.jsx
@@ -22,6 +22,8 @@ const Results = ({ results, userWatchlist }) => {
   const [filteredYearRange, setFilteredYearRange] = useState(null);
   const [filteredPopularityRange, setFilteredPopularityRange] = useState(null);
   const [excludeWatchlist, setExcludeWatchlist] = useState(true);
+  const [filteredLanguage, setFilteredLanguage] = useState(null);
+  const [maxRuntime, setMaxRuntime] = useState(null);
 
   const displayedResults = useMemo(() => {
     if (!results) {
@@ -72,6 +74,20 @@ const Results = ({ results, userWatchlist }) => {
       );
     }
 
+    // filter on language
+    if (filteredLanguage) {
+      output = output.filter(
+        (movie) => movie.movie_data.original_language === filteredLanguage,
+      );
+    }
+
+    // filter on max runtime
+    if (maxRuntime != null) {
+      output = output.filter(
+        (movie) => !movie.movie_data.runtime || movie.movie_data.runtime <= maxRuntime,
+      );
+    }
+
     return output.slice(0, 50);
   }, [
     results,
@@ -80,6 +96,8 @@ const Results = ({ results, userWatchlist }) => {
     filteredPopularityRange,
     excludeWatchlist,
     userWatchlist,
+    filteredLanguage,
+    maxRuntime,
   ]);
 
   return (
@@ -119,6 +137,8 @@ const Results = ({ results, userWatchlist }) => {
           setFilteredPopularityRange={setFilteredPopularityRange}
           excludeWatchlist={excludeWatchlist}
           setExcludeWatchlist={setExcludeWatchlist}
+          setFilteredLanguage={setFilteredLanguage}
+          setMaxRuntime={setMaxRuntime}
         />
       )}
       <div id="results">

--- a/frontend/src/styles/ListFilters.scss
+++ b/frontend/src/styles/ListFilters.scss
@@ -1,6 +1,11 @@
 #included-genre-filter,
-#excluded-genre-filter {
+#excluded-genre-filter,
+#language-filter {
   max-height: 3rem;
+  background-color: white;
+}
+
+#runtime-filter {
   background-color: white;
 }
 


### PR DESCRIPTION
## Summary
- Add **language dropdown** filter — populates from `original_language` in recommendation data, displays human-readable names via ISO 639-1 mapping, with "All" default
- Add **max runtime** text field filter (minutes) — filters recommendations by `runtime` field
- Add **genre select all / clear all** toggle button on the included genres filter

## Details
- No backend changes needed — `original_language` and `runtime` fields already exist in the parquet data served to the frontend
- No reseed required
- Only 3 frontend files modified: `ListFilters.jsx`, `Results.jsx`, `ListFilters.scss`
- Result limit remains at 50 (unchanged)

## Test plan
- [ ] `cd frontend && npm start` — confirm new filters render in the filter controls section
- [ ] With recommendations loaded, verify language dropdown populates from result data
- [ ] Selecting a language filters the recommendation list to only that language
- [ ] Entering a max runtime value filters out longer movies
- [ ] Genre "Select All" / "Clear All" button toggles all included genres
- [ ] Existing filters (year, genres, watchlist exclusion) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)