### PR TITLE
Add recommendations from an uploaded Letterboxd export

### DIFF
--- a/data_processing/get_user_ratings.py
+++ b/data_processing/get_user_ratings.py
@@ -160,7 +160,7 @@ def send_to_db(username, display_name, user_ratings):
             )
         )
 
-    safe_commit_ops(ratings, upsert_movies_operations)
+    safe_commit_ops(ratings, upsert_ratings_operations)
     safe_commit_ops(movies, upsert_movies_operations)
 
     return

--- a/data_processing/parse_export.py
+++ b/data_processing/parse_export.py
@@ -1,0 +1,265 @@
+#!/usr/local/bin/python3.12
+
+"""
+Turn the CSVs from a Letterboxd data export into the same user_data structure
+the scraper produces, so an upload can feed the recommendation model without
+scraping. The export ZIP is unzipped in the browser; this module only ever sees
+CSV text (a list of {name, text} files), never a ZIP.
+
+The export only contains film Name/Year/short-link, not the slug (movie_id) the
+model is keyed on, so Name + Year are resolved back to a slug using the rich
+movie data shipped with the project. Unresolved films are dropped -- they
+aren't in the model's universe, so they can't be folded in or recommended.
+"""
+
+import csv
+import glob
+import io
+import os
+import re
+import unicodedata
+
+import pandas as pd
+
+if os.getcwd().endswith("data_processing"):
+    from get_user_ratings import attach_synthetic_ratings
+else:
+    from data_processing.get_user_ratings import attach_synthetic_ratings
+
+
+# Export file (by archive path) -> category. Used to label uploaded CSVs
+_KNOWN_FILES = {
+    "ratings.csv": "ratings",
+    "watched.csv": "watched",
+    "watchlist.csv": "watchlist",
+    "diary.csv": "diary",
+    "likes/films.csv": "likes",
+    "profile.csv": "profile",
+}
+
+# Cached (exact_index, title_index) lookup, built lazily once per process
+_MOVIE_INDEX_CACHE = None
+
+
+def _rich_data_dir():
+    if os.getcwd().endswith("data_processing"):
+        return "data/rich_movie_data"
+    return "data_processing/data/rich_movie_data"
+
+
+def normalize_title(title):
+    """Lowercase and strip accents/punctuation so titles compare cleanly."""
+    if not title:  # guard None/"" so str(None) doesn't become "none"
+        return ""
+    s = unicodedata.normalize("NFKD", str(title))
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = re.sub(r"[^a-z0-9]+", " ", s.lower()).strip()
+    return s
+
+
+def _coerce_year(value):
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_movie_index(force=False):
+    """Cache lookups from the rich movie data: (title, year) -> slug and
+    title -> {slugs}, unioned across every shipped sample."""
+    global _MOVIE_INDEX_CACHE
+    if _MOVIE_INDEX_CACHE is not None and not force:
+        return _MOVIE_INDEX_CACHE
+
+    exact_index = {}
+    title_index = {}
+    for path in sorted(glob.glob(os.path.join(_rich_data_dir(), "*.parquet"))):
+        try:
+            df = pd.read_parquet(
+                path, columns=["movie_id", "movie_title", "year_released"]
+            )
+        except Exception:
+            continue
+        for movie_id, title, year in zip(
+            df["movie_id"], df["movie_title"], df["year_released"]
+        ):
+            if not isinstance(title, str) or not title or not isinstance(movie_id, str):
+                continue
+            norm = normalize_title(title)
+            if not norm:
+                continue
+            year_int = _coerce_year(year)
+            if year_int is not None:
+                exact_index.setdefault((norm, year_int), movie_id)
+            title_index.setdefault(norm, set()).add(movie_id)
+
+    _MOVIE_INDEX_CACHE = (exact_index, title_index)
+    return _MOVIE_INDEX_CACHE
+
+
+def resolve_movie_id(name, year, index=None):
+    """Resolve a film Name + Year to a Letterboxd slug, or None if not found."""
+    exact_index, title_index = index or build_movie_index()
+    norm = normalize_title(name)
+    if not norm:
+        return None
+
+    year_int = _coerce_year(year)
+    if year_int is not None:
+        # Exact year first, then tolerate off-by-one (release vs listed year)
+        for candidate in (year_int, year_int - 1, year_int + 1):
+            slug = exact_index.get((norm, candidate))
+            if slug:
+                return slug
+
+    candidates = title_index.get(norm)
+    if candidates and len(candidates) == 1:
+        return next(iter(candidates))
+    return None
+
+
+def _read_csv_rows(data):
+    if isinstance(data, bytes):
+        data = data.decode("utf-8-sig", errors="replace")
+    elif data and data[0] == "\ufeff":  # strip a UTF-8 BOM if present
+        data = data[1:]
+    reader = csv.DictReader(io.StringIO(data))
+    return [row for row in reader if any((v or "").strip() for v in row.values())]
+
+
+def _has_columns(rows, *names):
+    return bool(rows) and all(name in rows[0] for name in names)
+
+
+def classify_csv(filename, rows):
+    """Classify a CSV by filename, falling back to its columns."""
+    name = (filename or "").lower()
+    for key in ("watchlist", "diary", "ratings", "like", "watched"):
+        if key in name:
+            return "likes" if key == "like" else key
+    if _has_columns(rows, "Rating"):
+        return "diary" if _has_columns(rows, "Watched Date") else "ratings"
+    return "watched"
+
+
+def _stars_to_rating_val(raw):
+    """Convert 0.5-5.0 export stars to the model's 1-10 scale (the scraper's rated-N)."""
+    try:
+        stars = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return int(round(stars * 2)) if stars > 0 else None
+
+
+def build_categories_from_files(files):
+    """Sort uploaded CSVs into category -> rows. `files` is a list of
+    {name, text}; each file's category comes from its name (export path) or,
+    failing that, its columns."""
+    categories = {
+        k: [] for k in ("ratings", "diary", "watchlist", "watched", "likes", "profile")
+    }
+    for f in files or []:
+        if not isinstance(f, dict):
+            continue
+        text = f.get("text")
+        if not isinstance(text, str) or not text:
+            continue
+        rows = _read_csv_rows(text)
+        if not rows:
+            continue
+        key = (f.get("name") or "").lstrip("/")
+        category = _KNOWN_FILES.get(key) or classify_csv(key, rows)
+        if not categories[category]:  # first file of a category wins
+            categories[category] = rows
+    return categories
+
+
+def _entry_key(row):
+    uri = (row.get("Letterboxd URI") or "").strip()
+    return uri or f"{normalize_title(row.get('Name'))}|{_coerce_year(row.get('Year'))}"
+
+
+def build_user_data_from_files(files):
+    """Turn uploaded export CSVs into {user_ratings, watchlist, username,
+    display_name, num_explicit_ratings, status}, matching the scraper's
+    user_data. `files` is a list of {name, text}."""
+    categories = build_categories_from_files(files)
+    index = build_movie_index()
+
+    username = display_name = None
+    if categories["profile"]:
+        prof = categories["profile"][0]
+        username = (prof.get("Username") or "").strip().lower() or None
+        names = (
+            (prof.get("Given Name") or "").strip(),
+            (prof.get("Family Name") or "").strip(),
+        )
+        display_name = " ".join(p for p in names if p) or username
+
+    # Merge watched/rated/liked into one record per film. Unrated films keep
+    # rating_val -1 so they're still excluded from recs, like the scraper.
+    merged = {}
+
+    def _touch(row):
+        return merged.setdefault(
+            _entry_key(row),
+            {
+                "name": row.get("Name"),
+                "year": row.get("Year"),
+                "rating_val": -1,
+                "liked": False,
+            },
+        )
+
+    for row in categories["watched"]:
+        _touch(row)
+    for row in categories["ratings"] or categories["diary"]:  # ratings.csv preferred
+        rec = _touch(row)
+        rating_val = _stars_to_rating_val(row.get("Rating"))
+        if rating_val is not None:
+            rec["rating_val"] = rating_val
+    for row in categories["likes"]:
+        _touch(row)["liked"] = True
+
+    user_id = username or "uploaded-user"
+
+    # Resolve to slugs, dropping films not in the model; if two records resolve
+    # to the same slug, keep any explicit rating and any like.
+    user_ratings = {}
+    for rec in merged.values():
+        movie_id = resolve_movie_id(rec["name"], rec["year"], index)
+        if not movie_id:
+            continue
+        existing = user_ratings.get(movie_id)
+        if existing is None:
+            user_ratings[movie_id] = {
+                "movie_id": movie_id,
+                "rating_val": rec["rating_val"],
+                "user_id": user_id,
+                "liked": rec["liked"],
+            }
+        else:
+            if rec["rating_val"] >= 0:
+                existing["rating_val"] = rec["rating_val"]
+            existing["liked"] = existing["liked"] or rec["liked"]
+
+    user_ratings_list = list(user_ratings.values())
+    attach_synthetic_ratings(user_ratings_list, global_mean=8)
+
+    watchlist = []
+    seen = set()
+    for row in categories["watchlist"]:
+        movie_id = resolve_movie_id(row.get("Name"), row.get("Year"), index)
+        if movie_id and movie_id not in seen:
+            seen.add(movie_id)
+            watchlist.append(movie_id)
+
+    num_explicit = sum(1 for r in user_ratings_list if r["rating_val"] >= 0)
+    return {
+        "user_ratings": user_ratings_list,
+        "watchlist": watchlist,
+        "username": username,
+        "display_name": display_name,
+        "num_explicit_ratings": num_explicit,
+        "status": "success" if user_ratings_list or watchlist else "no_data",
+    }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "d3-scale": "^4.0.2",
+        "fflate": "^0.8.3",
         "prettier": "^2.5.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -7054,6 +7055,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "d3-scale": "^4.0.2",
+    "fflate": "^0.8.3",
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/src/components/Controls.jsx
+++ b/frontend/src/components/Controls.jsx
@@ -8,10 +8,41 @@ import {
   FormControl,
   TextField,
   Button,
+  ToggleButton,
+  ToggleButtonGroup,
 } from "@mui/material";
+
+import { unzipSync, strFromU8 } from "fflate";
 
 import LabeledSlider from "./ui/LabeledSlider";
 import { poll, getRecData } from "../util/util";
+
+// Export entries we send to the server (mirrors what the scraper gathers).
+// profile.csv is only sent when opting in, since it's only used to attribute
+// the database write and contains PII (email, bio) we otherwise don't need.
+const EXPORT_FILES = ["ratings.csv", "watched.csv", "watchlist.csv", "likes/films.csv"];
+const PROFILE_FILE = "profile.csv";
+
+// Guard so a decompression bomb can't blow up the user's own browser tab
+const MAX_UNZIP_BYTES = 60 * 1024 * 1024;
+
+// Unzip in the browser and return the relevant CSVs as [{name, text}]; a lone
+// CSV is sent as-is. The server only ever receives CSV text, never a ZIP.
+const extractExportFiles = async (file, includeProfile) => {
+  if (!file.name.toLowerCase().endsWith(".zip")) {
+    return [{ name: file.name, text: await file.text() }];
+  }
+
+  const wanted = new Set(includeProfile ? [...EXPORT_FILES, PROFILE_FILE] : EXPORT_FILES);
+  const entries = unzipSync(new Uint8Array(await file.arrayBuffer()), {
+    filter: (f) => wanted.has(f.name) && f.originalSize < MAX_UNZIP_BYTES,
+  });
+
+  return Object.entries(entries).map(([name, bytes]) => ({
+    name,
+    text: strFromU8(bytes),
+  }));
+};
 
 const validateData = (data, progressStep, setProgressStep, setRedisData) => {
   setRedisData(data);
@@ -49,22 +80,21 @@ const Controls = ({
 }) => {
   const POLL_INTERVAL = 1000;
 
+  const [inputMode, setInputMode] = useState("username");
   const [username, setUsername] = useState("");
+  const [file, setFile] = useState(null);
   const [modelStrength, setModelStrength] = useState(1000000);
   // const [popularityFilter, setPopularityFilter] = useState(-1)
   const [dataOptIn, setDataOptIn] = useState(false);
 
   const [runningModel, setRunningModel] = useState(false);
 
+  const usernameValid = /^[A-Za-z0-9_]*$/.test(username) && username !== "";
+  const canSubmit = !runningModel && (inputMode === "username" ? usernameValid : !!file);
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    setQueryData({
-      username,
-      modelStrength,
-      // popularityFilter,
-      dataOptIn,
-    });
+    if (!canSubmit) return;
 
     setRunningModel(true);
 
@@ -73,12 +103,59 @@ const Controls = ({
         ? "http://127.0.0.1:8000"
         : "https://letterboxd-recommendations.herokuapp.com";
 
-    const response = await fetch(
-      `${url}/get_recs?username=${username}&training_data_size=${modelStrength}&data_opt_in=${dataOptIn}`,
-      {
-        method: "GET",
-      },
-    );
+    let response;
+    if (inputMode === "upload") {
+      setQueryData({
+        isUpload: true,
+        filename: file.name,
+        modelStrength,
+        dataOptIn,
+      });
+
+      let files;
+      try {
+        files = await extractExportFiles(file, dataOptIn);
+      } catch (e) {
+        setQueryData({
+          error:
+            "Couldn't read that file. Please upload your Letterboxd export .zip or a CSV from it.",
+        });
+        setRunningModel(false);
+        return;
+      }
+
+      response = await fetch(
+        `${url}/get_recs_upload?training_data_size=${modelStrength}&data_opt_in=${dataOptIn}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ files }),
+        }
+      );
+    } else {
+      setQueryData({ username, modelStrength, dataOptIn });
+
+      response = await fetch(
+        `${url}/get_recs?username=${username}&training_data_size=${modelStrength}&data_opt_in=${dataOptIn}`,
+        {
+          method: "GET",
+        }
+      );
+    }
+
+    // A non-2xx response has no job ids; bail instead of polling garbage (which
+    // would otherwise leave the request spinning forever).
+    if (!response.ok) {
+      setQueryData({
+        error:
+          response.status === 413
+            ? "That file is too large to process. Try uploading just ratings.csv."
+            : "Something went wrong processing your request. Please try again.",
+      });
+      setRunningModel(false);
+      return;
+    }
+
     const data = await response.json();
 
     poll({
@@ -109,18 +186,64 @@ const Controls = ({
 
   return (
     <form className="recommendation-form" noValidate onSubmit={handleSubmit}>
-      <FormControl>
-        <TextField
-          required
-          error={!/^[A-Za-z0-9_]*$/.test(username)}
-          value={username}
-          pattern="^[A-Za-z0-9_]*$"
-          onInput={(e) => setUsername(e.target.value)}
-          helperText={"Please provide a valid Letterboxd username"}
-          label="Letterboxd Username"
-          variant="standard"
-        />
-      </FormControl>
+      <ToggleButtonGroup
+        className="input-mode-toggle"
+        value={inputMode}
+        exclusive
+        size="small"
+        onChange={(e, value) => value && setInputMode(value)}
+        aria-label="How to provide your Letterboxd data"
+      >
+        <ToggleButton value="username">Enter username</ToggleButton>
+        <ToggleButton value="upload">Upload export</ToggleButton>
+      </ToggleButtonGroup>
+
+      {inputMode === "username" ? (
+        <FormControl>
+          <TextField
+            required
+            error={!/^[A-Za-z0-9_]*$/.test(username)}
+            value={username}
+            pattern="^[A-Za-z0-9_]*$"
+            onInput={(e) => setUsername(e.target.value)}
+            helperText={"Please provide a valid Letterboxd username"}
+            label="Letterboxd Username"
+            variant="standard"
+          />
+        </FormControl>
+      ) : (
+        <div className="upload-control">
+          <Button variant="outlined" component="label" className="upload-button">
+            {file ? file.name : "Choose export file (.zip or .csv)"}
+            <input
+              type="file"
+              accept=".zip,.csv"
+              hidden
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+            />
+          </Button>
+
+          <div className="upload-instructions">
+            <p className="upload-instructions__heading">How to get your Letterboxd export:</p>
+            <ol>
+              <li>
+                On Letterboxd, open{" "}
+                <a target="_blank" rel="noreferrer" href="https://letterboxd.com/settings/data/">
+                  Settings → Data
+                </a>{" "}
+                and click <em>Export Your Data</em>.
+              </li>
+              <li>
+                Upload the downloaded <code>.zip</code> here (or just the <code>ratings.csv</code>{" "}
+                from inside it).
+              </li>
+            </ol>
+            <p className="upload-instructions__note">
+              Your file is used only to generate recommendations and isn't stored.
+            </p>
+          </div>
+        </div>
+      )}
 
       <FormGroup className={"form-slider"}>
         <LabeledSlider
@@ -173,20 +296,7 @@ const Controls = ({
       </FormGroup>
 
       <FormGroup className={"submit-button"}>
-        <Button
-          variant="contained"
-          type="submit"
-          disabled={
-            !/^[A-Za-z0-9_]*$/.test(username) ||
-            username === "" ||
-            runningModel === true
-          }
-          aria-disabled={
-            !/^[A-Za-z0-9_]*$/.test(username) ||
-            username === "" ||
-            runningModel === true
-          }
-        >
+        <Button variant="contained" type="submit" disabled={!canSubmit} aria-disabled={!canSubmit}>
           Get Recommendations
         </Button>
       </FormGroup>

--- a/frontend/src/components/ProgressTracking.jsx
+++ b/frontend/src/components/ProgressTracking.jsx
@@ -6,8 +6,13 @@ import { Checkmark, Error, Loader } from "./ui/StatefulIcons";
 
 const formatRatingGatherText = ({ queryData, redisData }) => {
   const userDataStatus = redisData?.statuses?.redis_get_user_data_job_status;
+  const userStatus = redisData?.execution_data?.user_status;
+  const isUpload = queryData.isUpload;
+
   if (userDataStatus !== "finished" && userDataStatus !== "failed") {
-    return (
+    return isUpload ? (
+      <>Reading ratings from your uploaded export ({queryData.filename})</>
+    ) : (
       <>
         Gathering movie ratings from {queryData.username}'s{" "}
         <a
@@ -19,8 +24,10 @@ const formatRatingGatherText = ({ queryData, redisData }) => {
         </a>
       </>
     );
-  } else if (redisData?.execution_data?.user_status === "user_not_found") {
+  } else if (userStatus === "user_not_found") {
     return `Could not find Letterboxd user: ${queryData.username}. Will return generic recommendations.`;
+  } else if (isUpload && userStatus === "no_data") {
+    return "Couldn't read any ratings from your upload. Will return generic recommendations.";
   } else {
     const numRatings = redisData.execution_data.num_user_ratings;
     const additionalRatingsPrompt =
@@ -28,7 +35,12 @@ const formatRatingGatherText = ({ queryData, redisData }) => {
         ? " (Rate more movies for more personalized results)"
         : "";
 
-    return (
+    return isUpload ? (
+      <>
+        Read {numRatings} movie ratings from your export
+        {additionalRatingsPrompt}
+      </>
+    ) : (
       <>
         Gathered {numRatings} movie ratings from {queryData.username}'s{" "}
         <a
@@ -126,7 +138,7 @@ const ProgressTracking = ({ queryData, redisData }) => {
                   : stageProgress.runModel === "finished"
                     ? "Generated"
                     : "Generate"}{" "}
-                recommendations for {queryData.username}
+                recommendations for {queryData.isUpload ? "you" : queryData.username}
               </span>
             </li>
           </>
@@ -138,8 +150,9 @@ const ProgressTracking = ({ queryData, redisData }) => {
                 <Error />
               </div>
               <span className="progress-text">
-                Sorry! Server is too busy with other requests right now. Try
-                again later.
+                {typeof queryData.error === "string"
+                  ? queryData.error
+                  : "Sorry! Server is too busy with other requests right now. Try again later."}
               </span>
             </li>
           )}

--- a/frontend/src/styles/Controls.scss
+++ b/frontend/src/styles/Controls.scss
@@ -43,6 +43,64 @@
   font-size: 1rem;
 }
 
+.input-mode-toggle {
+  align-self: center;
+  margin-bottom: 4px;
+
+  .MuiToggleButton-root {
+    text-transform: none;
+    font-size: 0.85rem;
+    padding: 4px 14px;
+  }
+}
+
+.upload-control {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.upload-button {
+  text-transform: none;
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.upload-instructions {
+  text-align: left;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: rgba(0, 0, 0, 0.75);
+
+  .upload-instructions__heading {
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  ol {
+    margin: 0;
+    padding-left: 18px;
+
+    li {
+      margin-bottom: 4px;
+    }
+  }
+
+  code {
+    font-family: "Roboto Mono", Inconsolata, Monaco, monospace;
+    font-size: 0.8rem;
+    background-color: #f0f0f0;
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+
+  .upload-instructions__note {
+    margin-top: 6px;
+    font-style: italic;
+    color: rgba(0, 0, 0, 0.55);
+  }
+}
+
 #body-content-container {
   min-height: 80vh;
 }

--- a/handle_recs.py
+++ b/handle_recs.py
@@ -4,8 +4,9 @@ import pandas as pd
 from rq import Queue, get_current_job
 from rq.registry import FinishedJobRegistry
 
-from data_processing.get_user_ratings import get_user_data
+from data_processing.get_user_ratings import get_user_data, send_to_db
 from data_processing.get_user_watchlist import get_watchlist_data
+from data_processing.parse_export import build_user_data_from_files
 from data_processing.run_model import get_movie_data, load_compressed_model, run_model
 from worker import conn
 
@@ -41,6 +42,41 @@ def get_client_user_data(username, data_opt_in, include_liked_items=True):
     current_job.save()
 
     return user_data[0]
+
+
+def get_client_user_data_from_upload(files, data_opt_in):
+    # Mirror get_client_user_data, but build user data from uploaded export CSVs
+    # (unzipped in the browser) instead of scraping, returning the same
+    # list-of-dicts for build_client_model
+    parsed = build_user_data_from_files(files)
+    user_ratings = parsed["user_ratings"]
+
+    # Best-effort opt-in DB write (needs a username from profile.csv); a DB
+    # problem should never fail the recommendation job
+    if data_opt_in and parsed["username"]:
+        explicit_ratings = [
+            {k: v for k, v in r.items() if k != "liked"}
+            for r in user_ratings
+            if r["rating_val"] >= 0
+        ]
+        if explicit_ratings:
+            try:
+                send_to_db(
+                    parsed["username"],
+                    parsed["display_name"] or parsed["username"],
+                    user_ratings=explicit_ratings,
+                )
+            except (Exception, SystemExit) as e:
+                # connect_to_db() raises SystemExit, not Exception, when unconfigured
+                print(f"Skipping opt-in DB write (database unavailable): {e}")
+
+    current_job = get_current_job(conn)
+    current_job.meta["user_status"] = parsed["status"]
+    current_job.meta["num_user_ratings"] = parsed["num_explicit_ratings"]
+    current_job.meta["user_watchlist"] = parsed["watchlist"]
+    current_job.save()
+
+    return user_ratings
 
 
 def build_client_model(username, training_data_rows=1000000, num_items=30):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,8 @@
-from fastapi import FastAPI
+import hashlib
+import json
+
+from fastapi import FastAPI, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -8,7 +12,11 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from rq.registry import DeferredJobRegistry
 
-from handle_recs import build_client_model, get_client_user_data
+from handle_recs import (
+    build_client_model,
+    get_client_user_data,
+    get_client_user_data_from_upload,
+)
 from worker import conn
 
 app = FastAPI()
@@ -29,6 +37,28 @@ popularity_thresholds_500k_samples = [2500, 2000, 1500, 1000, 700, 400, 250, 150
 
 USERDATA_CACHE_TTL = 300
 USERDATA_TTL_BUFFER = 10
+
+# Cap on the uploaded CSV bundle (JSON of all export CSVs). Even a power-user's
+# full bundle is only a few MB; this leaves generous headroom.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+
+async def _read_capped_body(request: Request, max_bytes: int) -> bytes | None:
+    """Read the request body, returning None if it exceeds max_bytes. Streams so
+    an oversized payload is never fully buffered (the length check on a fully
+    buffered body would be too late to prevent a memory blow-up)."""
+    content_length = request.headers.get("content-length")
+    if content_length and content_length.isdigit() and int(content_length) > max_bytes:
+        return None
+
+    chunks = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _ttl_for_job(job: Job) -> int | None:
@@ -58,21 +88,24 @@ def health():
     return {"ok": True}
 
 
-@app.get("/get_recs")
-def get_recs(username: str, training_data_size: int, data_opt_in: bool):
-    username = username.strip().lower()
-    # popularity_threshold = None
-    num_items = 2000
-
+def _enqueue_recs_pipeline(
+    *,
+    user_job_id,
+    user_job_callable,
+    user_job_args,
+    user_job_description,
+    model_username,
+    training_data_size,
+    num_items=2000,
+):
+    """Shared enqueue + cache logic for the user-data job followed by the
+    model-building job. Used by both the username (scrape) and upload flows."""
     ordered_queues = sorted(
         queue_pool, key=lambda queue: DeferredJobRegistry(queue=queue).count
     )
 
     print([(q, DeferredJobRegistry(queue=q).count) for q in ordered_queues])
     q = ordered_queues[0]
-
-    # set deterministic ID for user-data job
-    user_job_id = f"username-{username}__optin-{int(bool(data_opt_in))}"
 
     reused_cache = False
     job_get_user_data = None
@@ -107,13 +140,10 @@ def get_recs(username: str, training_data_size: int, data_opt_in: bool):
 
     if job_get_user_data is None:
         job_get_user_data = q.enqueue(
-            get_client_user_data,
-            args=(
-                username,
-                data_opt_in,
-            ),
+            user_job_callable,
+            args=user_job_args,
             job_id=user_job_id,
-            description=f"Scraping user data for {username} (sample: {training_data_size}, data_opt_in: {data_opt_in})",
+            description=user_job_description,
             result_ttl=120,
             ttl=200,
         )
@@ -124,12 +154,12 @@ def get_recs(username: str, training_data_size: int, data_opt_in: bool):
     job_build_model = q.enqueue(
         build_client_model,
         args=(
-            username,
+            model_username,
             training_data_size,
             num_items,
         ),
         depends_on=job_get_user_data,
-        description=f"Building model for {username} (sample: {training_data_size})",
+        description=f"Building model for {model_username} (sample: {training_data_size})",
         result_ttl=45,
         ttl=200,
     )
@@ -156,6 +186,75 @@ def get_recs(username: str, training_data_size: int, data_opt_in: bool):
                 "total_cache_time_seconds": USERDATA_CACHE_TTL,
             },
         }
+    )
+
+
+@app.get("/get_recs")
+def get_recs(username: str, training_data_size: int, data_opt_in: bool):
+    username = username.strip().lower()
+    # popularity_threshold = None
+
+    # set deterministic ID for user-data job
+    user_job_id = f"username-{username}__optin-{int(bool(data_opt_in))}"
+
+    return _enqueue_recs_pipeline(
+        user_job_id=user_job_id,
+        user_job_callable=get_client_user_data,
+        user_job_args=(username, data_opt_in),
+        user_job_description=(
+            f"Scraping user data for {username} "
+            f"(sample: {training_data_size}, data_opt_in: {data_opt_in})"
+        ),
+        model_username=username,
+        training_data_size=training_data_size,
+    )
+
+
+@app.post("/get_recs_upload")
+async def get_recs_upload(
+    request: Request,
+    training_data_size: int,
+    data_opt_in: bool = False,
+):
+    """Generate recommendations from an uploaded Letterboxd export.
+
+    The browser unzips the export and POSTs the CSV text as JSON
+    ({"files": [{"name", "text"}, ...]}); the server never handles a ZIP.
+    """
+    raw = await _read_capped_body(request, MAX_UPLOAD_BYTES)
+    if raw is None:
+        return JSONResponse(
+            status_code=413,
+            content={"error": "Uploaded data is too large."},
+        )
+    if not raw:
+        return JSONResponse(status_code=400, content={"error": "No data uploaded."})
+
+    try:
+        files = json.loads(raw)["files"]
+        if not isinstance(files, list):
+            raise ValueError
+    except (ValueError, KeyError, TypeError):
+        return JSONResponse(
+            status_code=400, content={"error": "Invalid upload payload."}
+        )
+
+    # Deterministic id so re-uploading the same file reuses the cached result.
+    content_hash = hashlib.sha1(raw).hexdigest()[:16]
+    user_job_id = f"upload-{content_hash}__optin-{int(bool(data_opt_in))}"
+    model_username = f"upload-{content_hash}"
+
+    # _enqueue_recs_pipeline does blocking Redis I/O; keep it off the event loop.
+    return await run_in_threadpool(
+        _enqueue_recs_pipeline,
+        user_job_id=user_job_id,
+        user_job_callable=get_client_user_data_from_upload,
+        user_job_args=(files, data_opt_in),
+        user_job_description=(
+            f"Parsing uploaded export ({len(files)} files, sample: {training_data_size})"
+        ),
+        model_username=model_username,
+        training_data_size=training_data_size,
     )
 
 

--- a/tests/unit/test_parse_export.py
+++ b/tests/unit/test_parse_export.py
@@ -1,0 +1,204 @@
+import pytest
+
+from data_processing import parse_export
+
+# These titles/years are chosen to exist in the rich movie data that ships with
+# the repo, so they resolve to real slugs. The "boxd.it" URIs are synthetic --
+# resolution is by Name + Year, not by the short link.
+RATINGS_CSV = (
+    "Date,Name,Year,Letterboxd URI,Rating\n"
+    "2021-01-20,Parasite,2019,https://boxd.it/aaaa,5\n"
+    "2021-01-26,Inception,2010,https://boxd.it/bbbb,4\n"
+    "2021-01-26,12 Angry Men,1957,https://boxd.it/cccc,4.5\n"
+    "2021-01-26,A Film That Is Not In The Dataset,2099,https://boxd.it/dddd,3\n"
+)
+
+WATCHED_CSV = (
+    "Date,Name,Year,Letterboxd URI\n"
+    "2021-01-20,Parasite,2019,https://boxd.it/aaaa\n"
+    "2021-01-20,Inception,2010,https://boxd.it/bbbb\n"
+    "2021-01-20,12 Angry Men,1957,https://boxd.it/cccc\n"
+    "2021-01-20,The Grand Budapest Hotel,2014,https://boxd.it/eeee\n"
+)
+
+WATCHLIST_CSV = (
+    "Date,Name,Year,Letterboxd URI\n"
+    "2021-01-21,Vertigo,1958,https://boxd.it/ffff\n"
+    "2021-01-21,Parasite,2019,https://boxd.it/aaaa\n"
+)
+
+LIKES_CSV = (
+    "Date,Name,Year,Letterboxd URI\n"
+    "2021-01-20,The Grand Budapest Hotel,2014,https://boxd.it/eeee\n"
+)
+
+PROFILE_CSV = (
+    "Date Joined,Username,Given Name,Family Name,Email Address,Location,"
+    "Website,Bio,Pronoun,Favorite Films\n"
+    "2021-01-20,TestUser,Test,Person,,,,,,\n"
+)
+
+
+def _full_export_files():
+    return [
+        {"name": "ratings.csv", "text": RATINGS_CSV},
+        {"name": "watched.csv", "text": WATCHED_CSV},
+        {"name": "watchlist.csv", "text": WATCHLIST_CSV},
+        {"name": "likes/films.csv", "text": LIKES_CSV},
+        {"name": "profile.csv", "text": PROFILE_CSV},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_title():
+    assert parse_export.normalize_title("The Grand Budapest Hotel") == (
+        "the grand budapest hotel"
+    )
+    assert parse_export.normalize_title("WALL·E") == "wall e"
+    assert parse_export.normalize_title("Amélie") == "amelie"
+    assert parse_export.normalize_title("12 Angry Men!") == "12 angry men"
+    assert parse_export.normalize_title(None) == ""  # no "none" false-match
+
+
+@pytest.mark.parametrize(
+    "stars,expected",
+    [
+        ("5", 10),
+        ("4.5", 9),
+        ("0.5", 1),
+        (3, 6),
+        ("0", None),
+        ("", None),
+        (None, None),
+        ("not-a-number", None),
+    ],
+)
+def test_stars_to_rating_val(stars, expected):
+    assert parse_export._stars_to_rating_val(stars) == expected
+
+
+def test_classify_csv_by_filename():
+    assert parse_export.classify_csv("watchlist.csv", []) == "watchlist"
+    assert parse_export.classify_csv("my-ratings.csv", []) == "ratings"
+    assert parse_export.classify_csv("likes/films.csv", []) == "likes"
+
+
+def test_classify_csv_by_columns():
+    rating_rows = [{"Name": "X", "Year": "2000", "Rating": "4"}]
+    assert parse_export.classify_csv("export.csv", rating_rows) == "ratings"
+
+    diary_rows = [{"Name": "X", "Rating": "4", "Watched Date": "2020-01-01"}]
+    assert parse_export.classify_csv("export.csv", diary_rows) == "diary"
+
+    watched_rows = [{"Name": "X", "Year": "2000"}]
+    assert parse_export.classify_csv("export.csv", watched_rows) == "watched"
+
+
+# ---------------------------------------------------------------------------
+# Resolution (depends on shipped rich movie data)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_movie_id_known_and_unknown():
+    assert parse_export.resolve_movie_id("Parasite", "2019") == "parasite-2019"
+    assert parse_export.resolve_movie_id("Inception", "2010") == "inception"
+    assert parse_export.resolve_movie_id("12 Angry Men", "1957") == "12-angry-men"
+    assert (
+        parse_export.resolve_movie_id("A Film That Is Not In The Dataset", "2099")
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sorting uploaded files into categories
+# ---------------------------------------------------------------------------
+
+
+def test_build_categories_from_files_uses_name_and_columns():
+    cats = parse_export.build_categories_from_files(
+        [
+            {"name": "likes/films.csv", "text": LIKES_CSV},
+            {"name": "renamed.csv", "text": WATCHLIST_CSV},  # classified by columns
+            {"name": "ignored", "text": ""},
+            {"name": "bad.csv", "text": 123},  # non-string text is skipped, not crashed
+            "not-a-dict",
+        ]
+    )
+    assert len(cats["likes"]) == 1
+    assert len(cats["watched"]) == 2  # WATCHLIST_CSV has no Rating column
+
+
+# ---------------------------------------------------------------------------
+# Building user data
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_data_from_full_export():
+    result = parse_export.build_user_data_from_files(_full_export_files())
+
+    assert result["status"] == "success"
+    assert result["username"] == "testuser"
+    assert result["display_name"] == "Test Person"
+
+    by_id = {r["movie_id"]: r for r in result["user_ratings"]}
+
+    # The unknown film is dropped; the 4 resolvable watched/rated films remain.
+    assert set(by_id) == {
+        "parasite-2019",
+        "inception",
+        "12-angry-men",
+        "the-grand-budapest-hotel",
+    }
+
+    # 5 stars -> 10, 4.5 stars -> 9 on the model's 1-10 scale.
+    assert by_id["parasite-2019"]["rating_val"] == 10
+    assert by_id["12-angry-men"]["rating_val"] == 9
+    assert result["num_explicit_ratings"] == 3
+
+    # Watched-but-unrated film is kept (so it's excluded from recs) at -1.
+    assert by_id["the-grand-budapest-hotel"]["rating_val"] == -1
+
+    # The liked-but-unrated film gets a synthetic rating.
+    assert by_id["the-grand-budapest-hotel"]["liked"] is True
+    assert "synthetic_rating_val" in by_id["the-grand-budapest-hotel"]
+
+    # Watchlist resolves and de-dupes.
+    assert result["watchlist"] == ["vertigo", "parasite-2019"]
+
+    # All entries are attributed to the profile username.
+    assert all(r["user_id"] == "testuser" for r in result["user_ratings"])
+
+
+def test_build_user_data_single_ratings_csv():
+    result = parse_export.build_user_data_from_files(
+        [{"name": "ratings.csv", "text": RATINGS_CSV}]
+    )
+
+    assert result["status"] == "success"
+    assert result["username"] is None
+    assert result["num_explicit_ratings"] == 3
+    # No watched.csv, so "seen" is just the rated films.
+    assert len(result["user_ratings"]) == 3
+    assert result["watchlist"] == []
+    assert all(r["user_id"] == "uploaded-user" for r in result["user_ratings"])
+
+
+def test_build_user_data_single_watchlist_csv():
+    result = parse_export.build_user_data_from_files(
+        [{"name": "watchlist.csv", "text": WATCHLIST_CSV}]
+    )
+
+    assert result["status"] == "success"
+    assert result["user_ratings"] == []
+    assert result["watchlist"] == ["vertigo", "parasite-2019"]
+
+
+def test_build_user_data_empty_is_no_data():
+    result = parse_export.build_user_data_from_files([])
+    assert result["status"] == "no_data"
+    assert result["user_ratings"] == []
+    assert result["watchlist"] == []


### PR DESCRIPTION
Given scraping keeps breaking or getting blocked, adding in a way to get recommendations by uploading Letterboxd data export instead. Can either upload whole .zip or just ratings.csv. Browser unzips and uploads just the relevant csvs to match the data collected via scraping.

Also a one line fix to send_to_db. it was committing the movie ops to the ratings collection instead of the actual ratings ops, so opt-in ratings were never getting saved (this affects the existing username flow too).
